### PR TITLE
The real intellisense

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,13 @@ basebuild will have strategies to different ecosystems and for now we're startin
 `To only aggregate config objects or config functions`
 ```typescript
 import basebuild from '@bebasebuild/basebuild'
+import { UserConfigFnObject } from 'vite'
 
-basebuild({
+basebuild<UserConfigFnObject>({
   configSystem: 'vite',
   configs: [
     configFunction1,
-    configObject2,
+    configFunction2,
     configFunction3,
   ]
 })
@@ -66,24 +67,24 @@ basebuild({
   ```typescript
     import basebuild from '@bebasebuild/basebuild'
     import vue from '@vitejs/plugin-vue'
-    import { UserConfig } from 'vite'
+    import { UserConfigFnObject } from 'vite'
 
-    export const basebuildVue = (userConfig: UserConfig) => {
+    export const basebuildVue = (userConfigFn) => {
 
-      const bbVueConfigFn = ({ command, basebuildDefaults }) => {
+      const bbVueConfigFn = ({ command, basebuild }) => {
         return {
           plugins: [
-            ...basebuildDefaults.plugins, // rollup-plugin-copy plugin
+            ...basebuild.defaults.plugins, // rollup-plugin-copy plugin
             vue()
           ]
         }
       }
 
-      return basebuild({
+      return basebuild<UserConfigFnObject>({
         configSystem: 'vite',
         configs: [
           bbVueConfigFn,
-          userConfig
+          userConfigFn
         ]
       })
     }
@@ -94,16 +95,16 @@ basebuild({
 
 
 <details>
-  <summary>To use the basebuild child project in vite.config.ts</summary>
+  <summary>To use the basebuild child project in vite.config.ts of any other projects</summary>
 
   ```typescript
     import basebuildVue from '@bebasebuild/basebuild-vue'
     import { splitVendorChunkPlugin } from 'vite'
 
-    export default basebuildVue(({ command, basebuildDefaults }) => {
+    export default basebuildVue(({ command, basebuild }) => {
       return {
         plugins: [
-          ...basebuildDefaults.plugins,
+          ...basebuild.defaults.plugins,
           splitVendorChunkPlugin()
         ] // now it should be [rollup-plugin-copy, vite-plugin-vue, vite-plugin-split-vendor-chunk]
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bebasebuild/basebuild",
   "description": "basebuild is the core project to build your own dev ecosystem.",
-  "version": "2.0.1-beta.1",
+  "version": "3.0.0-alpha.0",
   "packageManager": "yarn@1.22.19",
   "type": "module",
   "engines": {

--- a/src/apps/module/core/__tests__/index.test.ts
+++ b/src/apps/module/core/__tests__/index.test.ts
@@ -1,17 +1,18 @@
-import { vi } from 'vitest'
+import { UserConfig, vi } from 'vitest'
+import { UserConfig as VitestUserConfig } from 'vitest/config'
 import basebuildfy from '../index.js'
 import initializeStrategies from '../strategies/index.js'
 import test, { afterEach, beforeEach, describe } from 'node:test'
-import { ConfigEnv } from 'vite'
+import { ConfigEnv, UserConfig as ViteUserConfig, UserConfigFnObject as ViteConfigFnObject } from 'vite'
 import { ConfigEnv as ConfigEnvVitest } from 'vitest/config'
 
 
-const commonViteEnv: ConfigEnv = {
+const developmentViteEnv: ConfigEnv = {
   command: 'serve',
   mode: 'development'
 }
 
-const commonVitestEnv: ConfigEnvVitest = {
+const developmentVitestEnv: ConfigEnvVitest = {
   command: 'serve',
   mode: 'development'
 }
@@ -21,7 +22,7 @@ describe(`basebuildfy`, () => {
   //#region default
   describe(`when configs array is empty`, () => {
     it(`throw an error`, () => {
-      expect(() => basebuildfy()).toThrow('configs array is required')
+      expect(() => basebuildfy({ configs: undefined })).toThrow('configs array is required')
     })
   })
 
@@ -35,8 +36,8 @@ describe(`basebuildfy`, () => {
 
       it(`basebuildfies a single vite's config object`, () => {
         viteSpy = vi.spyOn(initializeStrategies, 'vite')
-        const finalConfigFunction = basebuildfy({ configs: [{}] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = basebuildfy<ViteUserConfig>({ configs: [{}] })
+        // const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
         expect(finalSettings).toMatchObject({})
@@ -48,10 +49,10 @@ describe(`basebuildfy`, () => {
         const configFunction = vi.fn()
 
         const finalConfigFunction = basebuildfy({ configs: [configFunction] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
-        expect(configFunction).toHaveBeenCalledWith({ ...commonViteEnv, basebuild: { defaults: {} } })
+        expect(configFunction).toHaveBeenCalledWith({ ...developmentViteEnv, basebuild: { defaults: {} } })
         expect(finalSettings).toMatchObject({})
       })
 
@@ -82,12 +83,12 @@ describe(`basebuildfy`, () => {
         })
 
         const finalConfigFunction = basebuildfy({ configs: [configFunction, configFunction2, configFunction3] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
-        expect(savedArgs1).toMatchObject({ ...commonViteEnv, basebuild: { defaults: {} } })
-        expect(savedArgs2).toMatchObject({ ...commonViteEnv, basebuild: { defaults: {} } })
-        expect(savedArgs3).toMatchObject({ ...commonViteEnv,
+        expect(savedArgs1).toMatchObject({ ...developmentViteEnv, basebuild: { defaults: {} } })
+        expect(savedArgs2).toMatchObject({ ...developmentViteEnv, basebuild: { defaults: {} } })
+        expect(savedArgs3).toMatchObject({ ...developmentViteEnv,
           basebuild: {
             defaults: { build: { minify: 'esbuild' } }
           }
@@ -113,8 +114,8 @@ describe(`basebuildfy`, () => {
 
       it(`basebuildfies a single vitest's config object`, () => {
         vitestSpy = vi.spyOn(initializeStrategies, 'vitest')
-        const finalConfigFunction = basebuildfy({ configSystem: 'vitest', configs: [{ globals: false }] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = basebuildfy<VitestUserConfig>({ configSystem: 'vitest', configs: [{}] })
+        // const finalSettings = finalConfigFunction(developmentVitestEnv)
 
         expect(vitestSpy).toHaveBeenCalled()
         expect(finalSettings).toMatchObject({})
@@ -126,10 +127,10 @@ describe(`basebuildfy`, () => {
         const configFunction = vi.fn()
 
         const finalConfigFunction = basebuildfy({ configSystem: 'vitest', configs: [configFunction] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = finalConfigFunction(developmentVitestEnv)
 
         expect(vitestSpy).toHaveBeenCalled()
-        expect(configFunction).toHaveBeenCalledWith({ ...commonViteEnv, basebuild: { defaults: {} } })
+        expect(configFunction).toHaveBeenCalledWith({ ...developmentVitestEnv, basebuild: { defaults: {} } })
         expect(finalSettings).toMatchObject({})
       })
 
@@ -160,13 +161,13 @@ describe(`basebuildfy`, () => {
         })
 
         const finalConfigFunction = basebuildfy({ configSystem: 'vitest', configs: [configFunction, configFunction2, configFunction3] })
-        const finalSettings = finalConfigFunction(commonViteEnv)
+        const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(vitestSpy).toHaveBeenCalled()
-        expect(savedArgs1).toMatchObject({ ...commonViteEnv, basebuild: { defaults: {} } })
-        expect(savedArgs2).toMatchObject({ ...commonViteEnv, basebuild: { defaults: {} } })
+        expect(savedArgs1).toMatchObject({ ...developmentViteEnv, basebuild: { defaults: {} } })
+        expect(savedArgs2).toMatchObject({ ...developmentViteEnv, basebuild: { defaults: {} } })
         expect(savedArgs3).toMatchObject({
-          ...commonViteEnv,
+          ...developmentViteEnv,
           basebuild: {
             defaults: { test: { globals: true } }
           }

--- a/src/apps/module/core/__tests__/index.test.ts
+++ b/src/apps/module/core/__tests__/index.test.ts
@@ -1,5 +1,5 @@
-import { UserConfig, vi } from 'vitest'
-import { UserConfig as VitestUserConfig } from 'vitest/config'
+import { Mock, UserConfig, vi } from 'vitest'
+import { UserConfig as VitestUserConfig, UserConfigFnObject as VitestViteConfigFnObject } from 'vitest/config'
 import basebuildfy from '../index.js'
 import initializeStrategies from '../strategies/index.js'
 import test, { afterEach, beforeEach, describe } from 'node:test'
@@ -36,8 +36,8 @@ describe(`basebuildfy`, () => {
 
       it(`basebuildfies a single vite's config object`, () => {
         viteSpy = vi.spyOn(initializeStrategies, 'vite')
-        const finalSettings = basebuildfy<ViteUserConfig>({ configs: [{}] })
-        // const finalSettings = finalConfigFunction(developmentViteEnv)
+        const finalConfigFunction = basebuildfy<ViteConfigFnObject>({ configs: [({ basebuild }) => { return {} }] })
+        const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
         expect(finalSettings).toMatchObject({})
@@ -48,7 +48,7 @@ describe(`basebuildfy`, () => {
 
         const configFunction = vi.fn()
 
-        const finalConfigFunction = basebuildfy({ configs: [configFunction] })
+        const finalConfigFunction = basebuildfy<ViteConfigFnObject>({ configs: [configFunction] })
         const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
@@ -82,7 +82,7 @@ describe(`basebuildfy`, () => {
           }
         })
 
-        const finalConfigFunction = basebuildfy({ configs: [configFunction, configFunction2, configFunction3] })
+        const finalConfigFunction = basebuildfy<Mock>({ configs: [configFunction, configFunction2, configFunction3] })
         const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(viteSpy).toHaveBeenCalled()
@@ -114,8 +114,8 @@ describe(`basebuildfy`, () => {
 
       it(`basebuildfies a single vitest's config object`, () => {
         vitestSpy = vi.spyOn(initializeStrategies, 'vitest')
-        const finalSettings = basebuildfy<VitestUserConfig>({ configSystem: 'vitest', configs: [{}] })
-        // const finalSettings = finalConfigFunction(developmentVitestEnv)
+        const finalConfigFunction = basebuildfy<VitestViteConfigFnObject>({ configSystem: 'vitest', configs: [() => { return {} }] })
+        const finalSettings = finalConfigFunction(developmentVitestEnv)
 
         expect(vitestSpy).toHaveBeenCalled()
         expect(finalSettings).toMatchObject({})
@@ -126,7 +126,7 @@ describe(`basebuildfy`, () => {
 
         const configFunction = vi.fn()
 
-        const finalConfigFunction = basebuildfy({ configSystem: 'vitest', configs: [configFunction] })
+        const finalConfigFunction = basebuildfy<VitestViteConfigFnObject>({ configSystem: 'vitest', configs: [configFunction] })
         const finalSettings = finalConfigFunction(developmentVitestEnv)
 
         expect(vitestSpy).toHaveBeenCalled()
@@ -160,7 +160,7 @@ describe(`basebuildfy`, () => {
           }
         })
 
-        const finalConfigFunction = basebuildfy({ configSystem: 'vitest', configs: [configFunction, configFunction2, configFunction3] })
+        const finalConfigFunction = basebuildfy<VitestViteConfigFnObject>({ configSystem: 'vitest', configs: [configFunction, configFunction2, configFunction3] })
         const finalSettings = finalConfigFunction(developmentViteEnv)
 
         expect(vitestSpy).toHaveBeenCalled()

--- a/src/apps/module/core/index.ts
+++ b/src/apps/module/core/index.ts
@@ -1,20 +1,20 @@
 import debug from 'debug'
-import { BasebuildCoreInitiazeOptions, ConfigSystemInitializer } from './types.js'
+import { BasebuildCoreInitializer, BasebuildCoreInitiazerOptions, ConfigSystemFn, ConfigSystemInitializer } from './types.js'
 import initializeStrategies from './strategies/index.js'
 
 const log = debug('basebuild:module:core')
 
-export const basebuildfy = (inializeOptions: BasebuildCoreInitiazeOptions = { configs: [] }) => {
-  const configSystem = inializeOptions?.configSystem || 'vite'
-  if (!inializeOptions?.configs?.length) {
+export const basebuildfy: BasebuildCoreInitializer = <T, K>(options: BasebuildCoreInitiazerOptions<T>) => {
+  const configSystem = options?.configSystem || 'vite'
+  if (!options?.configs?.length) {
     throw new Error('configs array is required')
   }
 
-  const strategy: ConfigSystemInitializer<any> = initializeStrategies[configSystem]
-  const finalViteConfig = strategy(inializeOptions?.configs)
+  const strategy = initializeStrategies[configSystem] as (configs: any) => T;
+  const finalConfigSystemResult = strategy(options?.configs)
 
-  log('finalViteConfig', finalViteConfig)
-  return finalViteConfig
+  log('finalConfigSystemResult', finalConfigSystemResult)
+  return finalConfigSystemResult
 }
 
 export default basebuildfy

--- a/src/apps/module/core/index.ts
+++ b/src/apps/module/core/index.ts
@@ -4,7 +4,7 @@ import initializeStrategies from './strategies/index.js'
 
 const log = debug('basebuild:module:core')
 
-export const basebuildfy: BasebuildCoreInitializer = <T, K>(options: BasebuildCoreInitiazerOptions<T>) => {
+export const basebuildfy: BasebuildCoreInitializer = <T>(options: BasebuildCoreInitiazerOptions<T>) => {
   const configSystem = options?.configSystem || 'vite'
   if (!options?.configs?.length) {
     throw new Error('configs array is required')

--- a/src/apps/module/core/strategies/vite/initializeByVite.ts
+++ b/src/apps/module/core/strategies/vite/initializeByVite.ts
@@ -1,8 +1,8 @@
-import { UserConfig, UserConfigFnObject, defineConfig } from "vite"
+import { UserConfig, UserConfigFnObject as ViteConfigFnObject, defineConfig } from "vite"
 import { mergeViteConfigs } from "./merge.js"
-import { ConfigSystemInitializer } from "../../../core/types.js"
+import { ConfigSystemInitializer, ConfigSystemSetting } from "../../../core/types.js"
 
-const initializeByVite: ConfigSystemInitializer<UserConfigFnObject> = (configs) => {
+const initializeByVite: ConfigSystemInitializer<ViteConfigFnObject> = (configs) => {
   const bbViteConfigFunction = mergeViteConfigs(configs)
   const finalViteConfig = defineConfig(bbViteConfigFunction)
   return finalViteConfig

--- a/src/apps/module/core/strategies/vite/merge.ts
+++ b/src/apps/module/core/strategies/vite/merge.ts
@@ -6,7 +6,7 @@ import getDefaultBasebuildViteConfig from './vite.config.js'
 
 const log = debug('basebuild:vite:merge')
 
-export const mergeViteConfigs: ConfigSystemMerger<UserConfigFnObject>  = (configs) => {
+export const mergeViteConfigs = (configs) => {
   return (configEnv: ConfigEnv): UserConfig => {
     const bbDefaultViteConfig = getDefaultBasebuildViteConfig(configEnv)
 

--- a/src/apps/module/core/strategies/vitest/initializeByVitest.ts
+++ b/src/apps/module/core/strategies/vitest/initializeByVitest.ts
@@ -1,8 +1,8 @@
-import { UserConfigFnObject, defineConfig } from "vitest/config"
+import { UserConfigFnObject as VitestConfigFnObject, defineConfig } from "vitest/config"
 import { mergeVitestConfigs } from "./merge.js"
 import { ConfigSystemInitializer } from "../../types.d.js"
 
-const initializeByVitest: ConfigSystemInitializer<UserConfigFnObject> = (configs) => {
+const initializeByVitest: ConfigSystemInitializer<VitestConfigFnObject> = (configs) => {
   const bbViteConfigFunction = mergeVitestConfigs(configs)
   const finalViteConfig = defineConfig(bbViteConfigFunction)
   return finalViteConfig

--- a/src/apps/module/core/strategies/vitest/merge.ts
+++ b/src/apps/module/core/strategies/vitest/merge.ts
@@ -6,7 +6,7 @@ import getDefaultBasebuildVitestConfig from './vite.config.js'
 
 const log = debug('basebuild:vite:merge')
 
-export const mergeVitestConfigs: ConfigSystemMerger<UserConfigFnObject> = (configs) => {
+export const mergeVitestConfigs = (configs) => {
   return (configEnv: ConfigEnv): UserConfig => {
     const bbDefaultViteConfig = getDefaultBasebuildVitestConfig(configEnv)
 

--- a/src/apps/module/core/types.d.ts
+++ b/src/apps/module/core/types.d.ts
@@ -1,25 +1,28 @@
 
 export type BasebuildCoreInitializer = {
   <T>(options: BasebuildCoreInitiazerOptions<T>): T;
-  <T, K>(options: BasebuildCoreInitiazerOptions<T>): K;
 }
 
 export interface BasebuildCoreInitiazerOptions<T> {
   configSystem?: ConfigSystemName;
-  configs: ConfigSystemSetting<T>[]
+  configs: ConfigSystemFn<T>[]
 }
 
 
-export type ConfigSystemSetting<T> = ConfigSystemFnOptions<T> | ConfigSystemFn<T>
+// export type ConfigSystemSetting<T> = ConfigSystemFn<T>
 export type ConfigSystemName = 'vite' | 'vitest'
-export type ConfigSystemFn<T> = (options: ConfigSystemFnOptions<T>) => T
-export interface ConfigSystemFnOptions<T> extends T {
+
+type FirstParam<T extends (...args: any) => any> = Parameters<T>[0]
+export interface ConfigSystemFnBBOptions<T> {
   basebuild?: {
-    defaults: T
+    defaults?: ReturnType<T>
   }
 }
+export type ConfigSystemFnOptions<T> = FirstParam<T> & ConfigSystemFnBBOptions<T>
+export type ConfigSystemFn<T extends (...args: any) => any> = (options: ConfigSystemFnOptions<T>) => ReturnType<T>
 
-export type ConfigSystemInitializer<T> = (configs: Array<ConfigSystemSetting<T>>) => T
-export type ConfigSystemMerger<T, K> = (configs: ConfigSystemSetting<T>[]) => K
+
+export type ConfigSystemInitializer<T> = (configs: ConfigSystemFn<T>[]) => T
+export type ConfigSystemMerger<T, K> = (configs: ConfigSystemFn<T>[]) => K
 
 

--- a/src/apps/module/core/types.d.ts
+++ b/src/apps/module/core/types.d.ts
@@ -1,19 +1,25 @@
 
-export interface BasebuildCoreInitiazeOptions {
-  configSystem?: ConfigSystemName
-  configs: ConfigSystemSetting[]
+export type BasebuildCoreInitializer = {
+  <T>(options: BasebuildCoreInitiazerOptions<T>): T;
+  <T, K>(options: BasebuildCoreInitiazerOptions<T>): K;
 }
 
-export type ConfigSystemSetting = ConfigSystemFnOptions<T> | ConfigSystemFn<T>
+export interface BasebuildCoreInitiazerOptions<T> {
+  configSystem?: ConfigSystemName;
+  configs: ConfigSystemSetting<T>[]
+}
+
+
+export type ConfigSystemSetting<T> = ConfigSystemFnOptions<T> | ConfigSystemFn<T>
 export type ConfigSystemName = 'vite' | 'vitest'
 export type ConfigSystemFn<T> = (options: ConfigSystemFnOptions<T>) => T
 export interface ConfigSystemFnOptions<T> extends T {
-  basebuild: {
+  basebuild?: {
     defaults: T
   }
 }
 
-export type ConfigSystemInitializer<T> = (configs: ConfigSystemSetting[]) => T
-export type ConfigSystemMerger<T> = (configs: ConfigSystemSetting[]) => T
+export type ConfigSystemInitializer<T> = (configs: Array<ConfigSystemSetting<T>>) => T
+export type ConfigSystemMerger<T, K> = (configs: ConfigSystemSetting<T>[]) => K
 
 


### PR DESCRIPTION
# 📦 WHAT
 * Config's pattern definition
 * Refactor of types to be comprehensive by intellisense
 * Remove Legacy version

# 🧐 WHY
* Defined types and runtime execution were not cohesive
* We were passing through a really complex problem when trying to unify objects and functions calls. Cause there are computed/calculed values that will only be builded in runtime execution. 
* And all this must consider the recursive calling as an issue. 
* `Remove Legacy version`:  we don't need the old code anymore :)

# 🎯 HOW
So, from now on... only function must be used to pass the configs on basebuildfy call. This way, we can achive the best of worlds: better standardization, better intellisense, better support for new ecosystems.
The first parameter will receive the `basebuild` property including the defaults
